### PR TITLE
Add test that examples match regular expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .tox
 *.pyc
+.venv

--- a/datasources.tsv
+++ b/datasources.tsv
@@ -12,7 +12,7 @@ BioSystems	Bs	http://www.ncbi.nlm.nih.gov/biosystems/	http://www.ncbi.nlm.nih.go
 BRENDA	Br	http://www.brenda-enzymes.org/	http://www.brenda-enzymes.org/enzyme.php?ecno=$id	1.1.1.1	protein		1	urn:miriam:brenda	^((\d+\.-\.-\.-)|(\d+\.\d+\.-\.-)|(\d+\.\d+\.\d+\.-)|(\d+\.\d+\.\d+\.\d+))$	BRENDA		brenda
 BRENDA Ligands	Brl	http://www.brenda-enzymes.org/	http://www.brenda-enzymes.de/ligand.php?brenda_ligand_id=$id	278	metabolite		1	Brl	^\d+$	BRENDA Ligands		brenda.ligand
 CAS	Ca	https://commonchemistry.cas.org/	https://commonchemistry.cas.org/detail?cas_rn=$id	50-00-0	metabolite		1	urn:miriam:cas	^\d{1,7}\-\d{2}\-\d$	CAS	P231	cas
-CCDS	Cc	http://identifiers.org/ccds/	http://www.ncbi.nlm.nih.gov/CCDS/CcdsBrowse.cgi?REQUEST=ALLFIELDS&DATA=$id	CCDS33337	gene		0	urn:miriam:ccds	^CCDS\d+\.\d+$	Consensus CDS		ccds
+CCDS	Cc	http://identifiers.org/ccds/	http://www.ncbi.nlm.nih.gov/CCDS/CcdsBrowse.cgi?REQUEST=ALLFIELDS&DATA=$id	CCDS33337.1	gene		0	urn:miriam:ccds	^CCDS\d+\.\d+$	Consensus CDS		ccds
 ChEMBL compound	Cl	https://www.ebi.ac.uk/chembldb/	https://www.ebi.ac.uk/chembl/compound/inspect/$id	CHEMBL308052	metabolite		1	urn:miriam:chembl.compound	^CHEMBL\d+$	ChEMBL compound	P592	chembl.compound
 ChEBI	Ce	http://www.ebi.ac.uk/chebi/	http://www.ebi.ac.uk/chebi/searchId.do?chebiId=$id	CHEBI:36927	metabolite		1	urn:miriam:chebi	^(CHEBI:)?\d+$	ChEBI	P683	chebi
 Chemspider	Cs	http://www.chemspider.com/	http://www.chemspider.com/Chemical-Structure.$id.html	56586	metabolite		1	urn:miriam:chemspider	^\d+$	ChemSpider	P661	chemspider
@@ -46,7 +46,7 @@ HGNC Accession number	Hac	http://www.genenames.org	https://www.genenames.org/dat
 HMDB	Ch	http://www.hmdb.ca/	http://www.hmdb.ca/metabolites/$id	HMDB0000001	metabolite		1	urn:miriam:hmdb	^HMDB(\d{2})?\d{5}$	HMDB	P2057	hmdb
 HomoloGene	Hg	http://www.ncbi.nlm.nih.gov/homologene/	http://www.ncbi.nlm.nih.gov/homologene/$id	1000	gene		1	urn:miriam:homologene	^\d+$	HomoloGene	P593	homologene
 HPRD	Hp	http://www.hprd.org/			interaction	Homo sapiens	1	urn:miriam:hprd		HPRD		
-Human Disease Ontology	Do	http://www.disease-ontology.org	https://identifiers.org/$id	doid:11337	unknown	Homo sapiens	1	urn:miriam:doid	^DOID\:\d+$	Disease Ontology		doid
+Human Disease Ontology	Do	http://www.disease-ontology.org	https://disease-ontology.org/?id=$id	DOID:11337	unknown	Homo sapiens	1	urn:miriam:doid	^DOID\:\d+$	Disease Ontology		doid
 ICD-9	ICD9	http://www.who.int/classifications/icd/en/	http://www.icd9data.com/getICD9Code.ashx?icd9=$id	104	unknown	Homo sapiens	1	ICD9	^\d+$	International Classification of Diseases		icd9
 ICD-10	ICD10	http://www.who.int/classifications/icd/en/	http://apps.who.int/classifications/icd10/browse/2010/en#/{$id}	C34	unknown	Homo sapiens	1	ICD10	^[A-Z]\d+(\.[-\d+])?$	International Classification of Diseases		icd10
 ICD-11	ICD11	http://www.who.int/classifications/icd/en/		1A95	unknown	Homo sapiens	1	ICD11	^([A-Z]|\d)+(\d|[A-Z])\d+$	International Classification of Diseases		
@@ -71,7 +71,7 @@ MACiE	Ma	http://www.ebi.ac.uk/thornton-srv/databases/MACiE/index.html	http://www
 MaizeGDB	Mg	https://maizegdb.org/	https://maizegdb.org/gene_center/gene/$id	acc1	gene	Zea mays	1	Mg		MaizeGDB		maizegdb.locus
 MatrixDB	Md	http://matrixdb.ibcp.fr/	http://matrixdb.ibcp.fr/cgi-bin/model/report/default?name=$id&class=Association	P00747_P07355	interaction		1	urn:miriam:matrixdb.association	^([A-N,R-Z][0-9][A-Z][A-Z, 0-9][A-Z, 0-9][0-9])_.*|([O,P,Q][0-9][A-Z, 0-9][A-Z, 0-9][A-Z, 0-9][0-9]_.*)|(GAG_.*)|(MULT_.*)|(PFRAG_.*)|(LIP_.*)|(CAT_.*)$	MatrixDB		matrixdb.association
 MeSH	Me	http://id.nlm.nih.gov/mesh/	http://id.nlm.nih.gov/mesh/$id	C000100	other		1	urn:miriam:mesh	^(C|D)\d{6}$	Medical Subject Headings		mesh
-MetaboLights Compounds	Ml	http://www.ebi.ac.uk/metabolights/	http://www.ebi.ac.uk/metabolights/$id	MTBLC17170	metabolite		1	Ml	^MTBLC\-\d{1,6}$	MetaboLights Compounds	P3890	metabolights
+MetaboLights Compounds	Ml	http://www.ebi.ac.uk/metabolights/	http://www.ebi.ac.uk/metabolights/$id	MTBLC17170	metabolite		1	Ml	^MTBLC\d{1,6}$	MetaboLights Compounds	P3890	metabolights
 MetaCyc	Mc	http://www.metacyc.org/	http://www.metacyc.org/META/NEW-IMAGE?type=NIL&object=$id	D-GLUTAMATE-OXIDASE-RXN	interaction		1	Mc		MetaCyc		metacyc.reaction
 MGI	M	http://www.informatics.jax.org/	http://www.informatics.jax.org/marker/$id	MGI:2442292	gene	Mus musculus	1	urn:miriam:mgd	^MGI:\d+$	Mouse Genome Database	P671	mgi
 MINT	Mi	http://mint.bio.uniroma2.it/mint/	http://mint.bio.uniroma2.it/mint/search/inFrameInteraction.do?interactionAc=$id	MINT-10000	interaction		1	urn:miriam:mint	^MINT\-\d{1,5}$	MINT		mint
@@ -118,7 +118,7 @@ SubstrateDB	Sdb	http://substrate.burnham.org/	http://substrate.burnham.org/prote
 SubtiWiki	Bsu	http://www.subtiwiki.uni-goettingen.de/wiki/index.php/Main_Page	http://www.subtiwiki.uni-goettingen.de/wiki/index.php/$id	BSU29180	gene	Bacillus subtilis	1	urn:miriam:subtiwiki	^BSU\d{5}$	SubtiWiki		subtiwiki
 SUPFAM	Sf	http://supfam.org/SUPERFAMILY/	http://supfam.org/SUPERFAMILY/cgi-bin/scop.cgi?ipid=$id	SSF57615	protein		1	urn:miriam:supfam	^\w+$	SUPFAM		supfam
 SWISS-MODEL	Sw	http://swissmodel.expasy.org/	http://swissmodel.expasy.org/repository/smr.php?sptr_ac=$id	P23298	protein		1	urn:miriam:swiss-model	^\w+$	SWISS-MODEL		swiss-model
-SwissLipids	Sl	http://www.swisslipids.org/	http://www.swisslipids.org/#/entity/$id/	SLM:000048885	metabolite		1		^SML:\d+$	SwissLipids		swisslipid
+SwissLipids	Sl	http://www.swisslipids.org/	http://www.swisslipids.org/#/entity/$id/	SLM:000048885	metabolite		1		^SLM:\d+$	SwissLipids		swisslipid
 Systems Biology Ontology	Sbo	http://www.ebi.ac.uk/sbo/	http://www.ebi.ac.uk/sbo/main/$id	SBO:0000262	ontology		1	urn:miriam:biomodels.sbo	^SBO:\d{7}$	Systems Biology Ontology		sbo
 TAIR	A	http://arabidopsis.org/index.jsp	http://arabidopsis.org/servlets/TairObject?type=locus&name=$id	AT1G01030	gene	Arabidopsis thaliana	1	urn:miriam:tair.locus	^AT[1-5]G\d{5}$	TAIR Locus		tair.locus
 TIGR	Ti	http://www.jcvi.org/		12012.t00308	gene		1	Ti		TIGR		

--- a/scripts/align_bioregistry.py
+++ b/scripts/align_bioregistry.py
@@ -99,7 +99,7 @@ def main():
         rows.append(row)
 
     df["bioregistry"] = prefixes
-    df.to_csv(DATASOURCES, index=False, header=False, sep='\t')
+    df.to_csv(DATASOURCES, index=False, header=False, sep="\t")
 
     curation_df = pd.DataFrame(rows, columns=df.columns)
     curation_df.to_csv(CURATION, sep="\t", index=False)

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -27,8 +27,19 @@ class TestIntegrity(unittest.TestCase):
         """Test the row lengths."""
         for i, line in enumerate(self.rows, start=1):
             self.assertEqual(
-                len(self.columns), len(line), msg=f"Row {i} has the wrong number of columns"
+                len(self.columns),
+                len(line),
+                msg=f"Row {i} has the wrong number of columns",
             )
+
+    def test_patterns(self):
+        """Check the example identifiers pass the given regular expressions."""
+        for i, line in enumerate(self.rows, start=1):
+            resource, example, pattern = line[0], line[4], line[9]
+            if not example or not pattern:
+                continue
+            with self.subTest(resource=resource, example=example, pattern=pattern):
+                self.assertRegex(example, pattern)
 
     def test_valid_bioregistry(self):
         """Test that Bioregistry prefixes are valid."""
@@ -38,5 +49,12 @@ class TestIntegrity(unittest.TestCase):
                 continue
             with self.subTest(resource=resource, prefix=bioregistry_prefix):
                 norm_prefix = bioregistry.normalize_prefix(bioregistry_prefix)
-                self.assertIsNotNone(norm_prefix, msg=f"unrecognized Bioregistry prefix: {bioregistry_prefix} in {resource}")
-                self.assertEqual(bioregistry_prefix, norm_prefix, msg="unstandardized Bioregistry prefix")
+                self.assertIsNotNone(
+                    norm_prefix,
+                    msg=f"unrecognized Bioregistry prefix: {bioregistry_prefix} in {resource}",
+                )
+                self.assertEqual(
+                    bioregistry_prefix,
+                    norm_prefix,
+                    msg="unstandardized Bioregistry prefix",
+                )


### PR DESCRIPTION
This PR does the following:

1. Adds a test for each row that has both a regular expression pattern and an example identifier, that the identifier is indeed matched by the regular expression. This identified 4 rows where this was not the case.
2. Updates the rows where this isn't the case
    - CCDS - I added the trailing `.1` to the example identifier, since this is actually what's shown when you resolve pages like http://www.ncbi.nlm.nih.gov/CCDS/CcdsBrowse.cgi?REQUEST=ALLFIELDS&DATA=CCDS33337
    - DOID - I capitalized the `DOID` redundant prefix in the identifier to match the regular expression. I also updated the redirect string, which DOID recently recommended in https://twitter.com/diseaseontology/status/1526229867200663554?s=20&t=NSRrgISkMNBDkDrHtYJqRw
    - Metabolights - removed a typo where there was a dash `-` in the regular expression, this is not actually part of identifiers
    - SwissLipids - fixed a typo where `SLM` was written as `SML`
3. Runs black, causes a bit of spurious diff, but worth it