### PR TITLE
Removed a discontinued database not used in WikiPathways 

### DIFF
--- a/datasources.tsv
+++ b/datasources.tsv
@@ -55,7 +55,6 @@ Illumina	Il	http://www.illumina.com/		ILMN_5668	probe		0	Il	ILMN_\d+	Illumina		i
 InChIKey	Ik	http://inchi.org/		QTBSBXVTEAMEQO-UHFFFAOYSA-N	metabolite		1	urn:miriam:inchikey	^[A-Z]{14}\-[A-Z]{10}(\-[A-Z])?	Standard InChIKey	P235	inchikey	metabolite
 IntAct	Ia	http://www.ebi.ac.uk/intact/	http://www.ebi.ac.uk/intact/pages/details/details.xhtml?interactionAc=$id	EBI-2307691	interaction		1	urn:miriam:intact	^EBI\-[0-9]+$	IntAct		intact	interaction
 InterPro	I	http://www.ebi.ac.uk/interpro/	https://www.ebi.ac.uk/interpro/entry/InterPro/$id	IPR000100	protein		1	urn:miriam:interpro	^IPR\d{6}$	InterPro	P2926	interpro	protein
-IPI	Ip	http://www.ebi.ac.uk/IPI	http://www.ebi.ac.uk/cgi-bin/dbfetch?db=IPI&id=$id&format=default	IPI00000001	protein		1		^IPI\d{8}$	IPI		interpro	protein
 IRGSP Gene	Ir	http://rgp.dna.affrc.go.jp/IRGSP/	https://rapdb.dna.affrc.go.jp/viewer/gbrowse_details/irgsp1?name=$id	Os12g0561000	gene		1	Ir	Os\d{2}g\d+	IRGSP Gene		rapdb.locus	gene
 ISBN	isbn	http://isbndb.com/	http://isbndb.com/search-all.html?kw=$id	9781584885658	publication		1	urn:miriam:isbn	^(ISBN)?(-13|-10)?[:]?[ ]?(\d{2,3}[ -]?)?\d{1,5}[ -]?\d{1,7}[ -]?\d{1,6}[ -]?(\d|X)$	ISBN	P212	isbn	publication
 ISSN	issn	https://portal.issn.org	https://portal.issn.org/resource/ISSN/$id	1776-3045	publication		1	urn:miriam:issn	^\d{4}-\d{3}[\dX]$	ISSN	P236	issn	publication


### PR DESCRIPTION
And deprecated in bioregistry.io

Actually, the bioregistry.io prefix was wrong: interpro is a different namespace, the correct one was 'ipi'

@AlexanderPico or @mkutmon, do you see any reason to keep it?